### PR TITLE
Add GitHub Action to use Carpenter CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,4 +30,3 @@ jobs:
           name: coverage
           path: htmlcov
           if-no-files-found: error
-

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,3 +30,4 @@ jobs:
           name: coverage
           path: htmlcov
           if-no-files-found: error
+

--- a/.github/workflows/carpenter.yaml
+++ b/.github/workflows/carpenter.yaml
@@ -2,7 +2,7 @@ name: Carpentry
 on:
   push:
     branches:
-      - gha-test
+      - main
   pull_request:
 env:
   IMAGE_NAME: arcaflow-plugin-template-python
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout this project
         uses: actions/checkout@v3
       - name: carpenter build
-        uses: mfleader/arcaflow-plugin-image-builder@gh-container-axn
+        uses: arcalot/arcaflow-plugin-image-builder
         with:
           args: build --build --push
 

--- a/.github/workflows/carpenter.yaml
+++ b/.github/workflows/carpenter.yaml
@@ -5,27 +5,27 @@ on:
       - gha-test
   pull_request:
 env:
-  # REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-  # PASSWORD_ENVVAR: "GITHUB_PASSWORD"
-  # USERNAME_ENVVAR: "GITHUB_USERNAME"
-  # GITHUB_USERNAME: ${{ github.actor }}
-  # GITHUB_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+  # IMAGE_NAME: ${{ github.repository }}
+  TARGET: arcaflow-plugin-template-python
+  GITHUB_USERNAME: ${{ github.actor }}
+  GITHUB_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
   QUAY_USERNAME: "mleader+carpenter"
-  QUAY_PASSWORD: ${{ secrets.QUAY_ROBOT_PASSWORD }}
+  QUAY_PASSWORD: ${{ secrets.QUAY_CARPENTER_PASSWORD }}
 jobs:
   carpenter-build:
     name: build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      # - name: pull carpenter
-      #   run: docker pull ghcr.io/mfleader/arcaflow-plugin-image-builder:gh-container-axn
-      - name: carpenter build
-        # run: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:z -v ${{ github.workspace }}:/github/workspace ghcr.io/mfleader/arcaflow-plugin-image-builder:gh-container-axn /carpenter build >> $GITHUB_STEP_SUMMARY
-        uses: mfleader/arcaflow-plugin-image-builder@gh-container-axn
-        with:
-          args: build --build --push
+      - name: github ref
+        run: echo ${{ github.ref }}
+      # - name: Checkout
+      #   uses: actions/checkout@v3
+      # # - name: pull carpenter
+      # #   run: docker pull ghcr.io/mfleader/arcaflow-plugin-image-builder:gh-container-axn
+      # - name: carpenter build
+      #   # run: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:z -v ${{ github.workspace }}:/github/workspace ghcr.io/mfleader/arcaflow-plugin-image-builder:gh-container-axn /carpenter build >> $GITHUB_STEP_SUMMARY
+      #   uses: mfleader/arcaflow-plugin-image-builder@gh-container-axn
+      #   with:
+      #     args: build --build --push
 
 

--- a/.github/workflows/carpenter.yaml
+++ b/.github/workflows/carpenter.yaml
@@ -20,5 +20,3 @@ jobs:
         uses: arcalot/arcaflow-plugin-image-builder
         with:
           args: build --build --push
-
-

--- a/.github/workflows/carpenter.yaml
+++ b/.github/workflows/carpenter.yaml
@@ -1,0 +1,21 @@
+name: Carpentry
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: carpenter build
+        uses: arcalot/arcaflow-plugin-image-builder
+      - name: whose workspace
+        run: |
+          echo ${{ github.workspace }}
+          echo $GITHUB_WORKSPACE
+
+

--- a/.github/workflows/carpenter.yaml
+++ b/.github/workflows/carpenter.yaml
@@ -2,20 +2,30 @@ name: Carpentry
 on:
   push:
     branches:
-      - main
+      - gha-test
   pull_request:
+env:
+  # REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  # PASSWORD_ENVVAR: "GITHUB_PASSWORD"
+  # USERNAME_ENVVAR: "GITHUB_USERNAME"
+  # GITHUB_USERNAME: ${{ github.actor }}
+  # GITHUB_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+  QUAY_USERNAME: "mleader+carpenter"
+  QUAY_PASSWORD: ${{ secrets.QUAY_ROBOT_PASSWORD }}
 jobs:
-  build:
-    name: Build
+  carpenter-build:
+    name: build
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
+      - name: Checkout
         uses: actions/checkout@v3
+      # - name: pull carpenter
+      #   run: docker pull ghcr.io/mfleader/arcaflow-plugin-image-builder:gh-container-axn
       - name: carpenter build
-        uses: arcalot/arcaflow-plugin-image-builder
-      - name: whose workspace
-        run: |
-          echo ${{ github.workspace }}
-          echo $GITHUB_WORKSPACE
+        # run: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:z -v ${{ github.workspace }}:/github/workspace ghcr.io/mfleader/arcaflow-plugin-image-builder:gh-container-axn /carpenter build >> $GITHUB_STEP_SUMMARY
+        uses: mfleader/arcaflow-plugin-image-builder@gh-container-axn
+        with:
+          args: build --build --push
 
 

--- a/.github/workflows/carpenter.yaml
+++ b/.github/workflows/carpenter.yaml
@@ -5,27 +5,20 @@ on:
       - gha-test
   pull_request:
 env:
-  # IMAGE_NAME: ${{ github.repository }}
-  TARGET: arcaflow-plugin-template-python
+  IMAGE_NAME: arcaflow-plugin-template-python
+  IMAGE_TAG: 'latest'
   GITHUB_USERNAME: ${{ github.actor }}
   GITHUB_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-  QUAY_USERNAME: "mleader+carpenter"
-  QUAY_PASSWORD: ${{ secrets.QUAY_CARPENTER_PASSWORD }}
 jobs:
   carpenter-build:
     name: build
     runs-on: ubuntu-latest
     steps:
-      - name: github ref
-        run: echo ${{ github.ref }}
-      # - name: Checkout
-      #   uses: actions/checkout@v3
-      # # - name: pull carpenter
-      # #   run: docker pull ghcr.io/mfleader/arcaflow-plugin-image-builder:gh-container-axn
-      # - name: carpenter build
-      #   # run: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:z -v ${{ github.workspace }}:/github/workspace ghcr.io/mfleader/arcaflow-plugin-image-builder:gh-container-axn /carpenter build >> $GITHUB_STEP_SUMMARY
-      #   uses: mfleader/arcaflow-plugin-image-builder@gh-container-axn
-      #   with:
-      #     args: build --build --push
+      - name: Checkout this project
+        uses: actions/checkout@v3
+      - name: carpenter build
+        uses: mfleader/arcaflow-plugin-image-builder@gh-container-axn
+        with:
+          args: build --build --push
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,12 @@ RUN pip3 install -r requirements.txt
 
 RUN mkdir /htmlcov
 RUN pip3 install coverage
-RUN /usr/local/bin/python3 -m coverage run test_example_plugin.py
-RUN /usr/local/bin/python3 -m coverage html -d /htmlcov
+RUN python3 -m coverage run test_example_plugin.py
+RUN python3 -m coverage html -d /htmlcov
 
 VOLUME /config
 
-ENTRYPOINT ["/usr/local/bin/python3", "/app/example_plugin.py"]
+ENTRYPOINT ["python3", "/app/example_plugin.py"]
 CMD []
 
 LABEL org.opencontainers.image.source="https://github.com/arcalot/arcaflow-plugin-template-python"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN /usr/local/bin/python3 -m coverage html -d /htmlcov
 VOLUME /config
 
 ENTRYPOINT ["/usr/local/bin/python3", "/app/example_plugin.py"]
-# CMD ["-f", "/config/example.yaml"]
 CMD []
 
 LABEL org.opencontainers.image.source="https://github.com/arcalot/arcaflow-plugin-template-python"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,29 @@
-FROM python:3.9
+FROM quay.io/centos/centos:stream8
 
+RUN dnf -y module install python39 && dnf -y install python39 python39-pip
 RUN mkdir /app
+ADD https://raw.githubusercontent.com/arcalot/arcaflow-plugins/main/LICENSE /app
 ADD example_plugin.py /app
 ADD test_example_plugin.py /app
 ADD requirements.txt /app
 WORKDIR /app
 
-RUN pip install -r requirements.txt
+RUN pip3 install -r requirements.txt
 
 RUN mkdir /htmlcov
-RUN pip install coverage
+RUN pip3 install coverage
 RUN /usr/local/bin/python3 -m coverage run test_example_plugin.py
 RUN /usr/local/bin/python3 -m coverage html -d /htmlcov
 
 VOLUME /config
 
 ENTRYPOINT ["/usr/local/bin/python3", "/app/example_plugin.py"]
-CMD ["-f", "/config/example.yaml"]
+# CMD ["-f", "/config/example.yaml"]
+CMD []
+
+LABEL org.opencontainers.image.source="https://github.com/arcalot/arcaflow-plugin-template-python"
+LABEL org.opencontainers.image.licenses="Apache-2.0+GPL-2.0-only"
+LABEL org.opencontainers.image.vendor="Arcalot project"
+LABEL org.opencontainers.image.authors="Arcalot contributors"
+LABEL org.opencontainers.image.title="Python Plugin Template"
+LABEL io.github.arcalot.arcaflow.plugin.version="1"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# Python Plugin Template Project

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # Python Plugin Template Project
+
+## Image Building
+
+You can change this plugin's image version tag in
+`.github/workflows/carpenter.yaml` by editing the
+`IMAGE_TAG` variable, and pushing that change to the
+branch designated in that workflow.

--- a/example_plugin.py
+++ b/example_plugin.py
@@ -34,8 +34,6 @@ class ErrorOutput:
     error: str
 
 
-# The following is a decorator (starting with @). We add this in front of our
-# function to define the metadata for our step.
 @plugin.step(
     id="hello-world",
     name="Hello world!",

--- a/example_plugin.py
+++ b/example_plugin.py
@@ -43,8 +43,8 @@ class ErrorOutput:
 def hello_world(
     params: InputParams,
 ) -> typing.Tuple[str, typing.Union[SuccessOutput, ErrorOutput]]:
-    """The function  is the implementation for the step. It needs the decorator
-    above to make it into a  step. The type hints for the params are required.
+    """The function is the implementation for the step. It needs the decorator
+    above to make it into a step. The type hints for the params are required.
 
     :param params:
 

--- a/example_plugin.py
+++ b/example_plugin.py
@@ -9,8 +9,10 @@ from arcaflow_plugin_sdk import plugin, validation
 @dataclass
 class InputParams:
     """
-    This is the data structure for the input parameters of the step defined below.
+    This is the data structure for the input parameters of the step defined
+    below.
     """
+
     name: typing.Annotated[str, validation.min(1)]
 
 
@@ -19,6 +21,7 @@ class SuccessOutput:
     """
     This is the output data structure for the success case.
     """
+
     message: str
 
 
@@ -27,33 +30,39 @@ class ErrorOutput:
     """
     This is the output data structure in the error  case.
     """
+
     error: str
 
 
-# The following is a decorator (starting with @). We add this in front of our function to define the metadata for our
-# step.
+# The following is a decorator (starting with @). We add this in front of our
+# function to define the metadata for our step.
 @plugin.step(
     id="hello-world",
     name="Hello world!",
     description="Says hello :)",
     outputs={"success": SuccessOutput, "error": ErrorOutput},
 )
-def hello_world(params: InputParams) -> typing.Tuple[str, typing.Union[SuccessOutput, ErrorOutput]]:
-    """
-    The function  is the implementation for the step. It needs the decorator above to make it into a  step. The type
-    hints for the params are required.
+def hello_world(
+    params: InputParams,
+) -> typing.Tuple[str, typing.Union[SuccessOutput, ErrorOutput]]:
+    """The function  is the implementation for the step. It needs the decorator
+    above to make it into a  step. The type hints for the params are required.
 
     :param params:
 
-    :return: the string identifying which output it is, as well the output structure
+    :return: the string identifying which output it is, as well the output
+        structure
     """
 
-    return "success", SuccessOutput(
-        "Hello, {}!".format(params.name))
+    return "success", SuccessOutput("Hello, {}!".format(params.name))
 
 
 if __name__ == "__main__":
-    sys.exit(plugin.run(plugin.build_schema(
-        # List your step functions here:
-        hello_world,
-    )))
+    sys.exit(
+        plugin.run(
+            plugin.build_schema(
+                # List your step functions here:
+                hello_world,
+            )
+        )
+    )

--- a/test_example_plugin.py
+++ b/test_example_plugin.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import re
 import unittest
 import example_plugin
 from arcaflow_plugin_sdk import plugin


### PR DESCRIPTION
## Changes introduced with this PR

Add a GitHub action to call Carpenter CI to check this project meets our plugin requirements, build the plugin image, and push it to a chosen registry.

Converge project towards Arcaflow Python Plugin requirements.
---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).