### PR TITLE
change license link reference from legacy arcaflow-plugins repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/centos/centos:stream8
 
 RUN dnf -y module install python39 && dnf -y install python39 python39-pip
 RUN mkdir /app
-ADD https://raw.githubusercontent.com/arcalot/arcaflow-plugins/main/LICENSE /app
+ADD https://raw.githubusercontent.com/arcalot/arcaflow-plugin-template-python/main/LICENSE /app
 ADD example_plugin.py /app
 ADD test_example_plugin.py /app
 ADD requirements.txt /app


### PR DESCRIPTION
## Changes introduced with this PR

Changing the reference to the license in the Dockerfile away from the legacy arcaflow-plugins repo.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).