### PR TITLE
updating carpenter build yaml template to reflect integration of Quay…

### DIFF
--- a/.github/workflows/carpenter_build.yaml
+++ b/.github/workflows/carpenter_build.yaml
@@ -3,7 +3,8 @@ on:
   pull_request:
 env:
   IMAGE_NAME: arcaflow-plugin-template-python
-  IMAGE_TAG: 'dev-build'
+  IMAGE_TAG: 'latest'
+  QUAY_IMG_EXP: 'never'
   GITHUB_USERNAME: ${{ github.actor }}
   GITHUB_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_NAMESPACE: ${{ github.repository_owner }}
@@ -11,10 +12,29 @@ env:
   QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
   QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 jobs:
-  carpenter-build:
-    name: build
+  carpenter-build-prod:
+    name: carpenter_build_prod
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     steps:
+      - name: Checkout this project
+        uses: actions/checkout@v3
+      - name: carpenter build
+        uses: arcalot/arcaflow-plugin-image-builder@main
+        with:
+          args: build --build
+  carpenter-build-dev:
+    name: carpenter_build_dev
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
+    steps:
+      - name: set_image_tag
+        run: |
+          export commit_hash=${{ github.sha }}
+          echo "IMAGE_TAG=${GITHUB_REF##*/}_${commit_hash:0:7}" >> $GITHUB_ENV
+      - name: set_quay_image_expiration
+        run: |
+          echo "QUAY_IMG_EXP=90d" >> $GITHUB_ENV
       - name: Checkout this project
         uses: actions/checkout@v3
       - name: carpenter build

--- a/.github/workflows/carpenter_push.yaml
+++ b/.github/workflows/carpenter_push.yaml
@@ -2,10 +2,11 @@ name: Carpentry Push
 on:
   push:
     branches:
-      - main
+      - "**"
 env:
-  IMAGE_NAME: arcaflow-plugin-template-python
+  IMAGE_NAME: arcaflow-plugin-uperf
   IMAGE_TAG: 'latest'
+  QUAY_IMG_EXP: 'never'
   GITHUB_USERNAME: ${{ github.actor }}
   GITHUB_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_NAMESPACE: ${{ github.repository_owner }}
@@ -13,10 +14,29 @@ env:
   QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
   QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 jobs:
-  carpenter-push:
-    name: carpenter_push
+  carpenter-build-prod:
+    name: carpenter_build_prod
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     steps:
+      - name: Checkout this project
+        uses: actions/checkout@v3
+      - name: carpenter build
+        uses: arcalot/arcaflow-plugin-image-builder@main
+        with:
+          args: build --build --push
+  carpenter-build-dev:
+    name: carpenter_build_dev
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
+    steps:
+      - name: set_image_tag
+        run: |
+          export commit_hash=${{ github.sha }}
+          echo "IMAGE_TAG=${GITHUB_REF##*/}_${commit_hash:0:7}" >> $GITHUB_ENV
+      - name: set_quay_image_expiration
+        run: |
+          echo "QUAY_IMG_EXP=90d" >> $GITHUB_ENV
       - name: Checkout this project
         uses: actions/checkout@v3
       - name: carpenter build

--- a/.github/workflows/carpenter_push.yaml
+++ b/.github/workflows/carpenter_push.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - "**"
 env:
-  IMAGE_NAME: arcaflow-plugin-uperf
+  IMAGE_NAME: arcaflow-plugin-template-python
   IMAGE_TAG: 'latest'
   QUAY_IMG_EXP: 'never'
   GITHUB_USERNAME: ${{ github.actor }}


### PR DESCRIPTION
… Image Expiration LABELS for dev images

Attempting to split the Jobs of carpenter by branch. If the build is triggered on the main branch it will build as normal and push to quay with the latest tag and the integration of quay expiration time label will be set to the default of never.
If the build is triggered under any other branch for development. It will create the image with a tag of the branch and small hash, as well as setting the quay expiration label to 90 days to auto delete from the quay repository. 

Please explain your changes here.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).