### PR TITLE
Added .flake8 file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+doctests = True
+exclude = .venv,.git,.tox,dist,doc,build,__pycache__
+max-line-length = 88


### PR DESCRIPTION
## Changes introduced with this PR
This PR adds a simple .flake8 config so that the `black` formatter doesn't conflict with the `flake8` linter.

The exclude component helps it not take excessively long while it searches all sub-folders pointlessly. It takes it from waiting maybe 5 seconds down to a near instant result.

88 is the line length that `black` uses, so that works well. That is up from the default of 79.

It's also possible to ignore some rules in this file. The bpench team set their config to ignore some. I'm not sure if that's important to anyone here.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).