### PR TITLE
Moving from ENV to ARG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
+ARG package=arcaflow_plugin_template_python
+
 # build poetry
 FROM quay.io/centos/centos:stream8 as poetry
-
+ARG package
 RUN dnf -y module install python39 && dnf -y install python39 python39-pip
 
 WORKDIR /app
@@ -12,8 +14,6 @@ RUN python3.9 -m pip install poetry \
  && python3.9 -m poetry config virtualenvs.create false \
  && python3.9 -m poetry install --without dev \
  && python3.9 -m poetry export -f requirements.txt --output requirements.txt --without-hashes
-
-ENV package arcaflow_plugin_template_python
 
 # run tests
 COPY ${package}/ /app/${package}
@@ -27,7 +27,7 @@ RUN python3 -m coverage html -d /htmlcov --omit=/usr/local/*
 
 # final image
 FROM quay.io/centos/centos:stream8
-ENV package arcaflow_plugin_template_python
+ARG package
 RUN dnf -y module install python39 && dnf -y install python39 python39-pip
 
 WORKDIR /app


### PR DESCRIPTION
## Changes introduced with this PR

Removing the `ENV` instruction and replacing it with a Dockerfile-wide [`ARG`](https://docs.docker.com/engine/reference/builder/#arg) to supply the package name. This will result in the `package` variable only being available at build time instead of runtime.

**Please note, this change is untested.**

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).