### PR TITLE
Update naming convention

### DIFF
--- a/.github/workflows/act.yaml
+++ b/.github/workflows/act.yaml
@@ -7,7 +7,7 @@ on:
     types:
       - published
 jobs:
-  carpenter:
+  act:
     uses: arcalot/arcaflow-container-toolkit.github/workflows/reusable_workflow.yaml@main
     with:
       image_name: ${{ github.event.repository.name }}

--- a/.github/workflows/act.yaml
+++ b/.github/workflows/act.yaml
@@ -8,7 +8,7 @@ on:
       - published
 jobs:
   act:
-    uses: arcalot/arcaflow-container-toolkit.github/workflows/reusable_workflow.yaml@main
+    uses: arcalot/arcaflow-container-toolkit/.github/workflows/reusable_workflow.yaml@main
     with:
       image_name: ${{ github.event.repository.name }}
       image_tag: 'latest'

--- a/.github/workflows/act.yaml
+++ b/.github/workflows/act.yaml
@@ -1,4 +1,4 @@
-name: Carpenter
+name: Arcaflow Container Toolkit
 on:
   push:
     branches:
@@ -8,7 +8,7 @@ on:
       - published
 jobs:
   carpenter:
-    uses: arcalot/arcaflow-reusable-workflows/.github/workflows/carpenter.yaml@main
+    uses: arcalot/arcaflow-container-toolkit.github/workflows/reusable_workflow.yaml@main
     with:
       image_name: ${{ github.event.repository.name }}
       image_tag: 'latest'


### PR DESCRIPTION
## Changes introduced with this PR

- Removing Carpenter naming convention in place to Arcaflow Container Toolkit for yaml file.
- Updating workflow link to use official workflow `arcalot/arcaflow-container-toolkit.github/workflows/reusable_workflow.yaml@main`

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).