### PR TITLE
Makes the plugin Runnable by the python deployer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN python3.9 -m pip install -r requirements.txt
 
 WORKDIR /app/${package}
 
-ENTRYPOINT ["python3", "arcaflow_plugin_template_python.py"]
+ENTRYPOINT ["python3", "-m", "arcaflow_plugin_template_python"]
 CMD []
 
 LABEL org.opencontainers.image.source="https://github.com/arcalot/arcaflow-plugin-template-python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["Arcalot"]
 license = "Apache-2.0+GPL-2.0-only"
-
+classifiers = ["Arcaflow :: Python Deployer :: Runnable"]
 packages = [
    { include="arcaflow_plugin_template_python.py", from="./arcaflow_plugin_template_python"  },
 ]


### PR DESCRIPTION
## Changes introduced with this PR
This change in the pyproject.toml will mark the plugin as runnable by the arcaflow-python-deployer adding to the pyproject.toml the capability `Arcaflow :: Python Deployer :: Runnable`.
The deployer will run a `pip show --verbose <module_name>` and, if the flag has been added in the capabilities field, will be printed to stdout and captured by the deployer that will run the plugin. If a plugin is not marked as Runnable won't be run by the deployer (unless the security checks are not explicitly overridden in the deployer config).

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).