### PR TITLE
Workflow Docsgen Update

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -20,5 +20,8 @@ jobs:
   docsgen:
     needs: act
     uses: arcalot/arcaflow-docsgen/.github/workflows/reusable_workflow.yaml@main
+    permissions:
+      contents: write
+      pull-requests: write
     with:
       plugin_path: "arcaflow_plugin_template_python/arcaflow_plugin_template_python.py"


### PR DESCRIPTION
## Changes introduced with this PR

Update to give permission from the caller workflow.
This will allow us to have tighter security at org level and adjust settings to all workflow to read-only

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).