### PR TITLE
Use new base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG package=arcaflow_plugin_template_python
 # STAGE 1 -- Build module dependencies and run tests
 # The 'poetry' and 'coverage' modules are installed and verson-controlled in the
 # quay.io/arcalot/arcaflow-plugin-baseimage-python-buildbase image to limit drift
-FROM quay.io/arcalot/arcaflow-plugin-baseimage-python-buildbase as build
+FROM quay.io/arcalot/arcaflow-plugin-baseimage-python-buildbase:0.1.0 as build
 ARG package
 
 COPY poetry.lock /app/
@@ -26,7 +26,7 @@ RUN python3.9 -m coverage run tests/test_${package}.py \
 
 
 # STAGE 2 -- Build final plugin image
-FROM quay.io/arcalot/arcaflow-plugin-baseimage-python-osbase
+FROM quay.io/arcalot/arcaflow-plugin-baseimage-python-osbase:0.1.0
 ARG package
 
 COPY --from=build /app/requirements.txt /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,13 @@
 ARG package=arcaflow_plugin_template_python
 
-# build poetry
-FROM quay.io/centos/centos:stream8 as poetry
+# STAGE 1 -- Build module dependencies and run tests
+FROM quay.io/arcalot/arcaflow-plugin-baseimage-python-buildbase as build
 ARG package
-RUN dnf -y module install python39 && dnf -y install python39 python39-pip
-
-WORKDIR /app
 
 COPY poetry.lock /app/
 COPY pyproject.toml /app/
 
-RUN python3.9 -m pip install poetry==1.4.2 \
- && python3.9 -m poetry config virtualenvs.create false \
- && python3.9 -m poetry install --without dev --no-root \
+RUN python3.9 -m poetry install --without dev --no-root \
  && python3.9 -m poetry export -f requirements.txt --output requirements.txt --without-hashes
 
 # run tests
@@ -22,21 +17,16 @@ COPY tests /app/${package}/tests
 ENV PYTHONPATH /app/${package}
 WORKDIR /app/${package}
 
-RUN mkdir /htmlcov
-RUN python3.9 -m pip install coverage==7.2.7 \
- && python3.9 -m coverage run tests/test_${package}.py \
+RUN python3.9 -m coverage run tests/test_${package}.py \
  && python3.9 -m coverage html -d /htmlcov --omit=/usr/local/*
 
 
-# final image
-FROM quay.io/centos/centos:stream8
+# STAGE 2 -- Build final plugin image
+FROM quay.io/arcalot/arcaflow-plugin-baseimage-python-osbase
 ARG package
-RUN dnf -y module install python39 && dnf -y install python39 python39-pip
 
-WORKDIR /app
-
-COPY --from=poetry /app/requirements.txt /app/
-COPY --from=poetry /htmlcov /htmlcov/
+COPY --from=build /app/requirements.txt /app/
+COPY --from=build /htmlcov /htmlcov/
 COPY LICENSE /app/
 COPY README.md /app/
 COPY ${package}/ /app/${package}


### PR DESCRIPTION
## Changes introduced with this PR

In order to better control drift that can lead to CI build failures, the Dockerfile is updated to use new Arcaflow base images where we can centrally control the OS and core dependencies.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).