### PR TITLE
don't run docsgen on main branch merges or releases

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -19,6 +19,7 @@ jobs:
       QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 
   docsgen:
+    if: github.ref != 'refs/heads/main' && github.event_name != 'release'
     needs: act
     uses: arcalot/arcaflow-docsgen/.github/workflows/reusable_workflow.yaml@main
     permissions:


### PR DESCRIPTION
## Changes introduced with this PR

Don't run docsgen on main or releases. Eliminates the unnecessary time and resources in the workflow process, and corrects an error condition that can happen in a merge race.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).