### PR TITLE
Remove `requirements.txt` and correct workflow triggers

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - v*
   pull_request:
 jobs:
   build:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -2,7 +2,10 @@ name: Arcaflow CI Workflow
 on:
   push:
     branches:
-      - "**"
+      - main
+    tags:
+      - v*
+  pull_request:
   release:
     types:
       - published

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-arcaflow-plugin-sdk==0.14.0 ; python_version >= "3.9" and python_version < "4.0"
-cbor2==5.6.3 ; python_version >= "3.9" and python_version < "4.0"
-pyyaml==6.0.1 ; python_version >= "3.9" and python_version < "4.0"


### PR DESCRIPTION
## Changes introduced with this PR

Since the `requirements.txt` file is generated during the build, there is no need to commit it to the repo.  Moreover, doing so distracts the Renovate bot, making maintenance harder and occasionally awkward.  This PR removes it from the repo so that new plugins created from this template won't acquire this useless file.

This PR also tweaks the workflow triggers so that they trigger for pull request updates, updates to the `main` branch and for tag creations, and not for updates to any upstream branch.  This will avoid the CI running twice when a PR refers to an upstream branch.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).